### PR TITLE
Image and histogram generation separation

### DIFF
--- a/quack.sh
+++ b/quack.sh
@@ -438,6 +438,12 @@ function makeImages() {
         local CONV="$SOURCE_IMAGE"
     fi
 
+    if [ ".true" == ".$PRESENTATION" ]; then
+        if shouldGenerate "$FORCE_PRESENTATION" "$PRESENTATION_IMAGE" "presentation"; then
+            $PRESENTATION_SCRIPT "$CONV" "$PRESENTATION_IMAGE"
+        fi
+    fi
+
     if [ ".true" == ".$TILE" ]; then
         if shouldGenerate "$FORCE_TILES" "$TILE_FOLDER" "tiles"; then
        # TODO: Specify JPEG quality
@@ -462,12 +468,6 @@ function makeImages() {
 
     if shouldGenerate "$FORCE_BLOWN" "$BLACK_IMAGE" "overlay"; then
         gm convert "$CONV" -black-threshold $BLOWN_BLACK_BT -white-threshold $BLOWN_BLACK_WT -fill \#$OVERLAY_BLACK -opaque black -transparent white -colors 2 "$BLACK_IMAGE"
-    fi
-
-    if [ ".true" == ".$PRESENTATION" ]; then
-        if shouldGenerate "$FORCE_PRESENTATION" "$PRESENTATION_IMAGE" "presentation"; then
-            $PRESENTATION_SCRIPT "$CONV" "$PRESENTATION_IMAGE"
-        fi
     fi
 
     if shouldGenerate "$FORCE_THUMBNAILS" "$THUMB_IMAGE" "thumbnail"; then


### PR DESCRIPTION
Generation of histograms is very memory hungry so relatively few concurrent histograms should be created at a time. Image generation requires less memory and thus works fine with more threads. This branch introduces different max threads for the two processes.
